### PR TITLE
Add styled menu with giraffe art

### DIFF
--- a/dailywordsearch/images/giraffe_background.svg
+++ b/dailywordsearch/images/giraffe_background.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <g stroke="#000" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <!-- head -->
+    <path d="M206 160 Q256 120 306 160 L306 260 Q256 300 206 260 Z"/>
+    <!-- horns -->
+    <line x1="236" y1="140" x2="236" y2="110"/>
+    <line x1="276" y1="140" x2="276" y2="110"/>
+    <!-- ears -->
+    <path d="M206 180 Q180 190 190 220"/>
+    <path d="M306 180 Q332 190 322 220"/>
+    <!-- glasses -->
+    <rect x="216" y="190" width="40" height="30"/>
+    <rect x="256" y="190" width="40" height="30"/>
+    <line x1="256" y1="205" x2="256" y2="205"/>
+    <!-- eyes -->
+    <circle cx="236" cy="205" r="4" fill="#000" stroke="none"/>
+    <circle cx="276" cy="205" r="4" fill="#000" stroke="none"/>
+    <!-- nose -->
+    <circle cx="246" cy="240" r="3" fill="#000" stroke="none"/>
+    <circle cx="266" cy="240" r="3" fill="#000" stroke="none"/>
+    <!-- mouth -->
+    <line x1="236" y1="250" x2="276" y2="250"/>
+    <!-- neck -->
+    <line x1="226" y1="260" x2="226" y2="320"/>
+    <line x1="286" y1="260" x2="286" y2="320"/>
+    <!-- bow tie -->
+    <polygon points="226,320 206,340 226,340"/>
+    <polygon points="286,320 306,340 286,340"/>
+    <rect x="226" y="330" width="60" height="10"/>
+  </g>
+</svg>

--- a/dailywordsearch/images/history_icon.svg
+++ b/dailywordsearch/images/history_icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <g stroke="#000" stroke-width="4" fill="none" stroke-linecap="round">
+    <circle cx="32" cy="32" r="28"/>
+    <line x1="32" y1="12" x2="32" y2="32"/>
+    <line x1="32" y1="32" x2="46" y2="32"/>
+    <circle cx="32" cy="32" r="4" fill="#000" stroke="none"/>
+  </g>
+</svg>

--- a/dailywordsearch/images/settings_icon.svg
+++ b/dailywordsearch/images/settings_icon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <g stroke="#000" stroke-width="4" fill="none" stroke-linecap="round">
+    <circle cx="32" cy="32" r="10"/>
+    <circle cx="32" cy="32" r="20"/>
+    <line x1="32" y1="2" x2="32" y2="10"/>
+    <line x1="32" y1="62" x2="32" y2="54"/>
+    <line x1="2" y1="32" x2="10" y2="32"/>
+    <line x1="62" y1="32" x2="54" y2="32"/>
+    <line x1="10" y1="10" x2="14" y2="14"/>
+    <line x1="54" y1="54" x2="50" y2="50"/>
+    <line x1="10" y1="54" x2="14" y2="50"/>
+    <line x1="54" y1="10" x2="50" y2="14"/>
+  </g>
+</svg>

--- a/dailywordsearch/scenes/MainMenu.tscn
+++ b/dailywordsearch/scenes/MainMenu.tscn
@@ -11,26 +11,50 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_i26rj")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
+[node name="Background" type="TextureRect" parent="."]
 layout_mode = 1
-anchors_preset = -1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+stretch_mode = 6
+
+[node name="SettingsButton" type="TextureButton" parent="."]
+layout_mode = 2
+anchors_preset = 5
+anchor_right = 1.0
+margin_right = -20.0
+margin_top = 20.0
+size_flags_horizontal = 0
+size_flags_vertical = 0
+
+[node name="HistoryButton" type="TextureButton" parent="."]
+layout_mode = 2
+anchors_preset = 5
+margin_left = 20.0
+margin_top = 20.0
+size_flags_horizontal = 0
+size_flags_vertical = 0
+
+[node name="ContentContainer" type="CenterContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 
-[node name="PlayButton" type="Button" parent="VBoxContainer"]
-custom_minimum_size = Vector2(0, 100)
+[node name="VBox" type="VBoxContainer" parent="ContentContainer"]
 layout_mode = 2
-size_flags_vertical = 4
-text = "PLAY"
 
-[node name="HistoryButton" type="Button" parent="VBoxContainer"]
-custom_minimum_size = Vector2(0, 100)
+[node name="Title" type="Label" parent="ContentContainer/VBox"]
 layout_mode = 2
-size_flags_vertical = 4
-text = "HISTORY"
+text = "Spectacled Giraffe Daily"
+horizontal_alignment = 1
+vertical_alignment = 1
 
-[node name="SettingsButton" type="Button" parent="VBoxContainer"]
-custom_minimum_size = Vector2(0, 100)
+[node name="PlayButton" type="Button" parent="ContentContainer/VBox"]
+custom_minimum_size = Vector2(0, 120)
 layout_mode = 2
+text = "Word Search Today"
+size_flags_horizontal = 4
 size_flags_vertical = 4
-text = "SETTINGS"

--- a/dailywordsearch/scripts/MainMenu.gd
+++ b/dailywordsearch/scripts/MainMenu.gd
@@ -1,13 +1,26 @@
 extends Control
 
-@onready var play_button = $VBoxContainer/PlayButton
-@onready var history_button = $VBoxContainer/HistoryButton
-@onready var settings_button = $VBoxContainer/SettingsButton
+@onready var play_button = $ContentContainer/VBox/PlayButton
+@onready var history_button = $HistoryButton
+@onready var settings_button = $SettingsButton
+@onready var title_label = $ContentContainer/VBox/Title
+@onready var background = $Background
 
 func _ready():
-	play_button.pressed.connect(_on_play_pressed)
-	history_button.pressed.connect(_on_history_pressed)
-	settings_button.pressed.connect(_on_settings_pressed)
+        play_button.pressed.connect(_on_play_pressed)
+        history_button.pressed.connect(_on_history_pressed)
+        settings_button.pressed.connect(_on_settings_pressed)
+        title_label.text = "Spectacled Giraffe Daily"
+        play_button.text = "Word Search Today"
+        background.texture = load("res://images/giraffe_background.svg")
+        var hist_tex = load("res://images/history_icon.svg")
+        history_button.texture_normal = hist_tex
+        history_button.texture_pressed = hist_tex
+        history_button.texture_hover = hist_tex
+        var set_tex = load("res://images/settings_icon.svg")
+        settings_button.texture_normal = set_tex
+        settings_button.texture_pressed = set_tex
+        settings_button.texture_hover = set_tex
 
 func _on_play_pressed():
 		var puzzle_scene = preload("res://scenes/PuzzleScreen.tscn").instantiate()


### PR DESCRIPTION
## Summary
- rework `MainMenu` layout to include background art and corner buttons
- create giraffe line-art background
- add settings and history icons
- update main menu script to load art assets

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684674d99aec8321be1622dce3a2d7e3