### PR TITLE
Add placeholder settings options

### DIFF
--- a/dailywordsearch/scenes/SettingsScreen.tscn
+++ b/dailywordsearch/scenes/SettingsScreen.tscn
@@ -20,6 +20,23 @@ grow_vertical = 2
 text = "SETTINGS"
 horizontal_alignment = 1
 
+[node name="AccessibilityCheck" type="CheckBox" parent="VBoxContainer"]
+text = "Colorblind Mode"
+
+[node name="SfxHBox" type="HBoxContainer" parent="VBoxContainer"]
+
+[node name="SfxLabel" type="Label" parent="VBoxContainer/SfxHBox"]
+text = "SFX Volume"
+
+[node name="SfxSlider" type="HSlider" parent="VBoxContainer/SfxHBox"]
+
+[node name="DarkModeCheck" type="CheckBox" parent="VBoxContainer"]
+text = "Dark Mode"
+
+[node name="LegalButton" type="Button" parent="VBoxContainer"]
+custom_minimum_size = Vector2(0, 100)
+text = "LEGAL"
+
 [node name="BackButton" type="Button" parent="VBoxContainer"]
 custom_minimum_size = Vector2(0, 100)
 text = "BACK"


### PR DESCRIPTION
## Summary
- add placeholders for settings options including accessibility, sfx, dark mode, and legal information

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68467580ee2c8321acad3b358daae375