### PR TITLE
Fix ThemeConfig references in PuzzleScreen

### DIFF
--- a/dailywordsearch/scripts/PuzzleScreen.gd
+++ b/dailywordsearch/scripts/PuzzleScreen.gd
@@ -4,6 +4,7 @@ extends Control
 @onready var grid = $MarginContainer/VBoxContainer/MarginContainer/AspectRatioContainer/GridContainer
 @onready var line_layer = $MarginContainer/VBoxContainer/MarginContainer/AspectRatioContainer/LineLayer
 @onready var back_button = $MarginContainer/VBoxContainer/HBoxContainer/back_button
+@onready var title_label = $MarginContainer/VBoxContainer/title
 @onready var word_list_col1 = [
 	$MarginContainer/VBoxContainer/word_list_container/word_columns/left_column/word_label_left_0,
 	$MarginContainer/VBoxContainer/word_list_container/word_columns/left_column/word_label_left_1,

--- a/dailywordsearch/scripts/ThemeConfig.gd
+++ b/dailywordsearch/scripts/ThemeConfig.gd
@@ -1,0 +1,12 @@
+extends Node
+class_name ThemeConfig
+
+# Colors used throughout the UI
+const BG_COLOR       : Color = Color(0.1, 0.1, 0.1)
+const LETTER_COLOR   : Color = Color(1, 1, 1)
+const LINE_COLOR     : Color = Color(0.8, 0.2, 0.2)
+
+# Font resource paths
+const TITLE_FONT_PATH = "res://fonts/Roboto-Bold.ttf"
+const GRID_FONT_PATH  = "res://fonts/Roboto-Regular.ttf"
+const WORD_FONT_PATH  = "res://fonts/Roboto-Bold.ttf"


### PR DESCRIPTION
## Summary
- add a new `ThemeConfig.gd` with basic color and font constants
- hook up the title label in `PuzzleScreen.gd`

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ab5480c08321861eb48130529776